### PR TITLE
feat: add retry_with_callback function for synchronous and asynchrono…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,8 @@ jobs:
               run: cargo llvm-cov --all-features --lcov --output-path lcov.info
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v3
+              uses: codecov/codecov-action@v5
               with:
                   files: lcov.info
                   fail_ci_if_error: false
+                  token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -114,7 +114,6 @@ where
 /// use tryumph::strategy::NoDelay;
 /// let mut collection = vec![1, 2].into_iter();
 /// let mut callback_called = false;
-
 /// let value = retry_with_callback(
 ///     NoDelay.take(2),
 ///     || match collection.next() {
@@ -131,7 +130,6 @@ where
 ///     },
 /// )
 /// .unwrap();
-
 /// assert_eq!(value, 2);
 /// assert_eq!(callback_called, true);
 /// ```

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -97,10 +97,7 @@ where
 ///
 /// * `iterable` - An iterable that provides the `Duration` to wait between retries.
 /// * `operation` - The operation to execute, typically a closure that returns a value convertible to `Result<O, E>`.
-/// * `callback` - A closure invoked after each failed operation attempt. It receives the `Result<O, E>`
-///                of the current attempt as an argument.
-///                If the callback returns `true`, retries are stopped, and the current error is returned immediately.
-///                If the callback returns `false`, retrying continues (if attempts remain).
+/// * `callback` - A closure invoked after each failed operation attempt. It receives the `Result<O, E>` of the current attempt as an argument. If the callback returns `true`, retries are stopped, and the current error is returned immediately. If the callback returns `false`, retrying continues (if attempts remain).
 ///
 /// # Returns
 ///

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -61,11 +61,11 @@ use std::{thread::sleep, time::Duration};
 ///     Ok::<_, &str>("success")
 /// });
 /// ```
-pub fn retry<I, O, R, E, OR>(iterable: I, mut operation: O) -> Result<R, E>
+pub fn retry<I, OP, R, O, E>(iterable: I, mut operation: OP) -> Result<O, E>
 where
     I: IntoIterator<Item = Duration>,
-    O: FnMut() -> OR,
-    OR: Into<Result<R, E>>,
+    OP: FnMut() -> R,
+    R: Into<Result<O, E>>,
 {
     let mut iter = iterable.into_iter();
 
@@ -84,12 +84,101 @@ where
     }
 }
 
+/// Executes an operation and retries it with a specified callback and delay intervals if it fails.
+///
+/// **Stability: This API is unstable and may change in future versions.**
+///
+/// This function repeatedly executes the provided operation until it succeeds, the callback
+/// indicates to stop, or there are no more retry attempts remaining. Before each retry,
+/// it waits for the duration provided by the next element from the iterable.
+/// If the operation fails, the callback function is invoked with the `Result` of the current attempt.
+///
+/// # Parameters
+///
+/// * `iterable` - An iterable that provides the `Duration` to wait between retries.
+/// * `operation` - The operation to execute, typically a closure that returns a value convertible to `Result<O, E>`.
+/// * `callback` - A closure invoked after each failed operation attempt. It receives the `Result<O, E>`
+///                of the current attempt as an argument.
+///                If the callback returns `true`, retries are stopped, and the current error is returned immediately.
+///                If the callback returns `false`, retrying continues (if attempts remain).
+///
+/// # Returns
+///
+/// Returns `Ok(O)` if the operation eventually succeeds.
+/// Returns the last encountered error `Err(E)` if all retries fail or if the callback indicates to stop.
+///
+/// # Examples
+///
+/// ```
+/// use tryumph::sync::retry_with_callback;
+/// use tryumph::strategy::NoDelay;
+/// let mut collection = vec![1, 2].into_iter();
+/// let mut callback_called = false;
+
+/// let value = retry_with_callback(
+///     NoDelay.take(2),
+///     || match collection.next() {
+///         Some(n) if n == 2 => Ok(n),
+///         Some(_) => Err("not 2"),
+///         None => Err("not 2"),
+///     },
+///     |result| {
+///         if let Err(e) = result {
+///             callback_called = true;
+///             assert_eq!(e, "not 2");
+///         }
+///         false // Continue retrying
+///     },
+/// )
+/// .unwrap();
+
+/// assert_eq!(value, 2);
+/// assert_eq!(callback_called, true);
+/// ```
+pub fn retry_with_callback<I, OP, C, R, O, E>(
+    iterable: I,
+    mut operation: OP,
+    mut callback: C,
+) -> Result<O, E>
+where
+    I: IntoIterator<Item = Duration>,
+    OP: FnMut() -> R,
+    C: FnMut(Result<O, E>) -> bool,
+    E: Clone,
+    R: Into<Result<O, E>>,
+{
+    let mut iter = iterable.into_iter();
+
+    loop {
+        // Invoke the factory to obtain a new Result for this attempt.
+        match operation().into() {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                if let Some(duration) = iter.next() {
+                    // Call the callback with the error
+                    if callback(Err(err.clone())) {
+                        // If the callback returns true, we stop retrying
+                        return Err(err);
+                    }
+
+                    sleep(duration);
+                } else {
+                    return Err(err); // No more retries left; returning the last error
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use super::retry;
-    use crate::strategy::{Exponential, Fixed, NoDelay};
+    use crate::{
+        strategy::{Exponential, Fixed, NoDelay},
+        sync::retry_with_callback,
+    };
 
     #[test]
     fn succeeds_with_infinite_retries() {
@@ -196,6 +285,32 @@ mod tests {
         .unwrap();
 
         assert_eq!(value, 2);
+    }
+
+    #[test]
+    fn retry_with_callback_test() {
+        let mut collection = vec![1, 2].into_iter();
+        let mut callback_called = false;
+
+        let value = retry_with_callback(
+            NoDelay.take(2),
+            || match collection.next() {
+                Some(n) if n == 2 => Ok(n),
+                Some(_) => Err("not 2"),
+                None => Err("not 2"),
+            },
+            |result| {
+                if let Err(e) = result {
+                    callback_called = true;
+                    assert_eq!(e, "not 2");
+                }
+                false // Continue retrying
+            },
+        )
+        .unwrap();
+
+        assert_eq!(value, 2);
+        assert_eq!(callback_called, true);
     }
 
     #[test]


### PR DESCRIPTION
…us retries
This pull request introduces significant enhancements to the retry functionality in both synchronous and asynchronous contexts by adding support for callback mechanisms. It also includes refactoring of the existing retry functions for improved clarity and consistency. The most important changes are summarized below:

### Enhancements to Retry Functionality

* Added a new `retry_with_callback` function to the synchronous module (`src/sync/mod.rs`). This function supports retrying operations with a callback that can decide whether to continue or stop based on the result of each attempt. It includes detailed documentation and an example.
* Added a new `retry_with_callback` function to the asynchronous module (`src/unsync/mod.rs`). This function mirrors the synchronous version but works with asynchronous operations and callbacks. It includes detailed documentation and an example.

### Refactoring for Consistency

* Refactored the existing `retry` function in the synchronous module to improve type parameter naming and consistency. The `operation` closure now directly returns a result convertible to `Result<O, E>`.
* Refactored the existing `retry` function in the asynchronous module to align with the changes made in the synchronous version, ensuring consistent type parameter naming and behavior.

### New Test Coverage

* Added unit tests for the new `retry_with_callback` function in both the synchronous (`src/sync/mod.rs`) and asynchronous (`src/unsync/mod.rs`) modules to verify functionality and edge cases. [[1]](diffhunk://#diff-9b53e9c68992870529cf70a2c621e9d3c49a6cebfe2fcae51e9e6e8a1653f1e3R290-R315) [[2]](diffhunk://#diff-3b9765f39b99249315fa8a485acf2907d4a2a5df43a15177fbac0d537bf0828dR414-R445)